### PR TITLE
add use strict

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,4 @@
+"use strict";
 
 let RULES = require('./rules')
 let cheerio = require('cheerio')

--- a/lib/rules/author.js
+++ b/lib/rules/author.js
@@ -1,3 +1,4 @@
+"use strict";
 
 let isUrl = require('is-url')
 let toTitle = require('to-title-case')

--- a/lib/rules/date.js
+++ b/lib/rules/date.js
@@ -1,3 +1,4 @@
+"use strict";
 
 let isIso = require('is-isodate')
 let chrono = require('chrono-node')

--- a/lib/rules/description.js
+++ b/lib/rules/description.js
@@ -1,3 +1,4 @@
+"use strict";
 
 /**
  * Wrap a rule with validation and formatting logic.

--- a/lib/rules/image.js
+++ b/lib/rules/image.js
@@ -1,3 +1,4 @@
+"use strict";
 
 let isUrl = require('is-url')
 

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -1,3 +1,4 @@
+"use strict";
 
 let author = require ('./author')
 let date = require ('./date')

--- a/lib/rules/publisher.js
+++ b/lib/rules/publisher.js
@@ -1,3 +1,4 @@
+"use strict";
 
 /**
  * Wrap a rule with validation and formatting logic.

--- a/lib/rules/title.js
+++ b/lib/rules/title.js
@@ -1,3 +1,4 @@
+"use strict";
 
 /**
  * Wrap a rule with validation and formatting logic.

--- a/lib/rules/url.js
+++ b/lib/rules/url.js
@@ -1,3 +1,4 @@
+"use strict";
 
 let isUrl = require('is-url')
 

--- a/support/comparison/index.js
+++ b/support/comparison/index.js
@@ -1,3 +1,4 @@
+"use strict";
 
 const SCRAPERS = require('./scrapers')
 const URLS = require('./urls')

--- a/support/comparison/scrapers.js
+++ b/support/comparison/scrapers.js
@@ -1,3 +1,4 @@
+"use strict";
 
 /**
  * Scrapers.

--- a/test/browser.js
+++ b/test/browser.js
@@ -1,3 +1,4 @@
+"use strict";
 
 /**
  * Polyfills.

--- a/test/fixtures/rules/async-rule/rules.js
+++ b/test/fixtures/rules/async-rule/rules.js
@@ -1,3 +1,4 @@
+"use strict";
 
 module.exports = {
   title: ($) => {

--- a/test/fixtures/rules/wrapped-rule/rules.js
+++ b/test/fixtures/rules/wrapped-rule/rules.js
@@ -1,3 +1,4 @@
+"use strict";
 
 module.exports = {
   title: wrap($ => $('title').text()),

--- a/test/server.js
+++ b/test/server.js
@@ -1,3 +1,4 @@
+"use strict";
 
 const assert = require('assert')
 const fs = require('fs')


### PR DESCRIPTION
Block-scoped declarations were throwing an error without strict mode enabled. This commit implements `"use strict";` in
* `lib/index.js`
* `rules/author.js`
* `rules/date.js`
* `rules/description.js`
* `rules/image.js`
* `rules/index.js`
* `rules/publisher.js`
* `rules/title.js`
* `rules/url.js`

CLOSES: #19 