### PR TITLE
Returns resolved URL rather than requested URL

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -32,7 +32,7 @@ function scrapeUrl(url, rules) {
   })
 
   return request.then((res) => {
-    return scrapeMetadata(res.body, url, rules)
+    return scrapeMetadata(res.body, res.url, rules)
   })
 }
 

--- a/test/server.js
+++ b/test/server.js
@@ -27,7 +27,7 @@ describe('server', () => {
           image: 'https://static01.nyt.com/images/2016/05/25/us/25PRIMARYweb/25PRIMARYweb-facebookJumbo.jpg',
           publisher: 'NYTimes',
           title: 'Reeling From 2016 Chaos, G.O.P. Mulls Overhaul of Primaries',
-          url: 'http://www.nytimes.com/2016/05/25/us/politics/republican-primary-schedule.html',
+          url: 'https://www.nytimes.com/2016/05/25/us/politics/republican-primary-schedule.html',
         })
       })
     })
@@ -49,7 +49,7 @@ describe('server', () => {
             image: 'https://static01.nyt.com/images/2016/05/25/us/25PRIMARYweb/25PRIMARYweb-facebookJumbo.jpg',
             publisher: 'NYTimes',
             title: 'Reeling From 2016 Chaos, G.O.P. Mulls Overhaul of Primaries',
-            url: 'http://www.nytimes.com/2016/05/25/us/politics/republican-primary-schedule.html',
+            url: 'https://www.nytimes.com/2016/05/25/us/politics/republican-primary-schedule.html',
           })
         })
       })
@@ -66,7 +66,7 @@ describe('server', () => {
             image: 'https://static01.nyt.com/images/2016/05/25/us/25PRIMARYweb/25PRIMARYweb-facebookJumbo.jpg',
             publisher: 'NYTimes',
             title: 'Reeling From 2016 Chaos, G.O.P. Mulls Overhaul of Primaries',
-            url: 'http://www.nytimes.com/2016/05/25/us/politics/republican-primary-schedule.html',
+            url: 'https://www.nytimes.com/2016/05/25/us/politics/republican-primary-schedule.html',
           })
         })
       })


### PR DESCRIPTION
Currently, the URL returned by the fallback from the url rule is not actually useful, as it's the requested URL rather than the resolved URL (after redirects). This allows the user to obtain the requested URL instead by overriding the rules for URL.

Note that `og:url` and `twitter:url` don't really seem very useful as well - for example, Google uses the URL of their daily doodle here rather than the actual homepage - so it may be worth reconsidering the general usage of this field. 