### PR TITLE
Passing headers to scrapeUrl

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -264,7 +264,16 @@ import Metascraper from 'metascraper'
 const metadata = await Metascraper.scrapeUrl(url)
 ```
 
-Scrapes a `url` with an optional set of `rules`.
+Scrapes a `url` with an optional set of `rules`. Instead of an url also an object can be passed to `Metascraper.scrapeUrl` to set HTTP headers for the request:
+
+```json
+{
+	"url": "https://www.example.com",
+	"headers": {
+		"Accept-Language": "en"
+	}
+}
+```
 
 #### `Metascraper.scrapeHtml(html, [rules])`
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,25 +16,27 @@ function scrapeHtml(html, rules) {
 }
 
 /**
- * Scrape metadata from `url`.
+ * Scrape metadata from an url.
  *
- * @param {String} url
+ * @param {String | Object} options (Can be an url as a string or an object with options.url and options.headers. options.url is required.)
  * @param {Object} rules (optional)
  * @return {Promise} metadata
  */
 
-function scrapeUrl(url, rules) {
-  let request = popsicle.request({
-    url,
-    options: {
-      jar: process.browser ? null : popsicle.jar()
-    }
-  })
-
-  return request.then((res) => {
-    return scrapeMetadata(res.body, res.url, rules)
-  })
-}
+function scrapeUrl(options, rules) {
+	var url = (typeof options === 'string') ? options : options.url;
+	var request = popsicle.request({
+	  url: url,
+	  options: {
+		jar: process.browser ? null : popsicle.jar()
+	  },
+	  headers: options.headers
+	});
+  
+	return request.then(function (res) {
+	  return scrapeMetadata(res.body, res.url, rules);
+	});
+  }
 
 /**
  * Scrape metadata from `window`.


### PR DESCRIPTION
As proposed in #34 and as I also needed the possibility to pass custom headers to scrapeUrl I made this pull request.

To maintain backwards compatibility I modified the scrapeUrl method so that either a string (url) or an object (containing of url and a headers object) can be passed as first argument. I also mentioned this in the Readme.md.